### PR TITLE
update the export workflow schedules so data is pushed to Artsdata every day

### DIFF
--- a/.github/workflows/export-artsculturenb-to-artsdata.yml
+++ b/.github/workflows/export-artsculturenb-to-artsdata.yml
@@ -3,7 +3,7 @@ name: Export artsculturenb calendar to Artsdata (V2)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 9 * * 1,4"  # Run at 5:30 AM EST (9:30 AM GMT) every Monday and Thursday
+    - cron: "15 6 * * *"  # Run at 1:15 AM EST (6:15 AM GMT) every day
 
 jobs:
   call-export-workflow:

--- a/.github/workflows/export-artsculturenb-to-artsdata.yml
+++ b/.github/workflows/export-artsculturenb-to-artsdata.yml
@@ -3,7 +3,7 @@ name: Export artsculturenb calendar to Artsdata (V2)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 9 * * 4"  # Run at 5:30 AM EST (9:30 AM GMT) every Thursday
+    - cron: "30 9 * * 1,4"  # Run at 5:30 AM EST (9:30 AM GMT) every Monday and Thursday
 
 jobs:
   call-export-workflow:

--- a/.github/workflows/export-culture-mauricie-entities-to-artsdata.yml
+++ b/.github/workflows/export-culture-mauricie-entities-to-artsdata.yml
@@ -3,7 +3,7 @@ name: Export Culture Mauricie (DICI.ca) calendar to Artsdata (V2)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 6 * * 1,3"  # Run at 2:00 AM EST every Monday and Wednesday
+    - cron: "0 6 * * *"  # Run at 1:00 AM EST (6:00 AM GMT) every day
 jobs:
   call-export-workflow:
     uses: ./.github/workflows/export-cms-entitiesv2.yml

--- a/.github/workflows/export-culture-mauricie-entities-to-artsdata.yml
+++ b/.github/workflows/export-culture-mauricie-entities-to-artsdata.yml
@@ -3,7 +3,7 @@ name: Export Culture Mauricie (DICI.ca) calendar to Artsdata (V2)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 6 * * 3"  # Run at 2:00 AM EST every Wednesday
+    - cron: "0 6 * * 1,3"  # Run at 2:00 AM EST every Monday and Wednesday
 jobs:
   call-export-workflow:
     uses: ./.github/workflows/export-cms-entitiesv2.yml

--- a/.github/workflows/export-indigenous-performances-calendar-to-artsdata.yml
+++ b/.github/workflows/export-indigenous-performances-calendar-to-artsdata.yml
@@ -3,7 +3,7 @@ name: Export Indigenous Performances calendar to Artsdata (V2)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "45 21 * * 3"  # Run at 5:45 PM EST, every Wednesday
+    - cron: "45 21 * * 1,3"  # Run at 5:45 PM EST, every Monday and Wednesday
 
 jobs:
   call-export-workflow:

--- a/.github/workflows/export-indigenous-performances-calendar-to-artsdata.yml
+++ b/.github/workflows/export-indigenous-performances-calendar-to-artsdata.yml
@@ -3,7 +3,7 @@ name: Export Indigenous Performances calendar to Artsdata (V2)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "45 21 * * 1,3"  # Run at 5:45 PM EST, every Monday and Wednesday
+    - cron: "30 6 * * *"  # Run at 1:30 AM EST (6:30 AM GMT) every day
 
 jobs:
   call-export-workflow:

--- a/.github/workflows/export-nac-osaka-to-artsdata.yml
+++ b/.github/workflows/export-nac-osaka-to-artsdata.yml
@@ -3,7 +3,7 @@ name: Export NAC Osaka calendar to Artsdata
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 5 * * 1,3"  # Run at 1:30 AM EST every Monday and Wednesday (5:30 GMT)
+    - cron: "30 5 * * *"  # Run at 12:30 AM EST (5:30 AM GMT) every day
 jobs:
   call-export-workflow:
     uses: ./.github/workflows/export-cms-entitiesv2.yml

--- a/.github/workflows/export-nac-osaka-to-artsdata.yml
+++ b/.github/workflows/export-nac-osaka-to-artsdata.yml
@@ -2,8 +2,8 @@ name: Export NAC Osaka calendar to Artsdata
 
 on:
   workflow_dispatch:
-    schedule:
-      - cron: "30 5 * * 3"  # Run at 1:30 AM EST every Wednesday (5:30 GMT)
+  schedule:
+    - cron: "30 5 * * 1,3"  # Run at 1:30 AM EST every Monday and Wednesday (5:30 GMT)
 jobs:
   call-export-workflow:
     uses: ./.github/workflows/export-cms-entitiesv2.yml

--- a/.github/workflows/export-signe-laval-entities-to-artsdata.yml
+++ b/.github/workflows/export-signe-laval-entities-to-artsdata.yml
@@ -3,7 +3,7 @@ name: Export Signe Laval calendar to Artsdata (V2)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 5 * * 1,3,5"  # Run at 1:00 AM EST every Monday, Wednesday and Friday
+    - cron: "0 5 * * *"  # Run at 12:00 AM EST (5:00 AM GMT) every day
 jobs:
   call-export-workflow:
     uses: ./.github/workflows/export-cms-entitiesv2.yml

--- a/.github/workflows/export-tourisme-mauricie-entities-to-artsdata.yml
+++ b/.github/workflows/export-tourisme-mauricie-entities-to-artsdata.yml
@@ -3,7 +3,7 @@ name: Export Tourisme Mauricie calendar to Artsdata (V2)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 5 * * 1,4"  # Run at 1:30 AM EST every Monday and Thursday
+    - cron: "45 5 * * *"  # Run at 12:45 AM EST (5:45 AM GMT) every day
 jobs:
   call-export-workflow:
     uses: ./.github/workflows/export-cms-entitiesv2.yml

--- a/.github/workflows/export-tourisme-mauricie-entities-to-artsdata.yml
+++ b/.github/workflows/export-tourisme-mauricie-entities-to-artsdata.yml
@@ -3,7 +3,7 @@ name: Export Tourisme Mauricie calendar to Artsdata (V2)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 5 * * 4"  # Run at 1:30 AM EST every Thursday
+    - cron: "30 5 * * 1,4"  # Run at 1:30 AM EST every Monday and Thursday
 jobs:
   call-export-workflow:
     uses: ./.github/workflows/export-cms-entitiesv2.yml

--- a/.github/workflows/export-tout-culture-entities-to-artsdata.yml
+++ b/.github/workflows/export-tout-culture-entities-to-artsdata.yml
@@ -3,7 +3,7 @@ name: Export Tout Culture calendar to Artsdata (V2)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 5 * * 4"  # Run at 1:00 AM EST every Thursday
+    - cron: "0 5 * * 1,4"  # Run at 1:00 AM EST every Monday and Thursday
 jobs:
   call-export-workflow:
     uses: ./.github/workflows/export-cms-entitiesv2.yml

--- a/.github/workflows/export-tout-culture-entities-to-artsdata.yml
+++ b/.github/workflows/export-tout-culture-entities-to-artsdata.yml
@@ -3,7 +3,7 @@ name: Export Tout Culture calendar to Artsdata (V2)
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 5 * * 1,4"  # Run at 1:00 AM EST every Monday and Thursday
+    - cron: "15 5 * * *"  # Run at 12:15 AM EST (5:15 AM GMT) every day
 jobs:
   call-export-workflow:
     uses: ./.github/workflows/export-cms-entitiesv2.yml


### PR DESCRIPTION
## Summary
This PR updates the export workflow schedules so data is pushed to Artsdata every day, with a clear 15-minute gap between each workflow run.  
Manual run support stays unchanged.

## Why
The goal is to keep Artsdata imports fresher and more reliable by running exports more frequently and avoiding overlapping jobs.

Ref: https://github.com/culturecreates/footlight-app/issues/2218

## What changed
- Converted scheduled workflows from weekly patterns to daily schedules.
- Kept workflow_dispatch in place for manual runs.

## New run sequence (UTC)
| Order | Workflow | New schedule |
|---|---|---|
| 1 | export-signe-laval-entities-to-artsdata.yml | 05:00 daily |
| 2 | export-tout-culture-entities-to-artsdata.yml | 05:15 daily |
| 3 | export-nac-osaka-to-artsdata.yml | 05:30 daily |
| 4 | export-tourisme-mauricie-entities-to-artsdata.yml | 05:45 daily |
| 5 | export-culture-mauricie-entities-to-artsdata.yml | 06:00 daily |
| 6 | export-artsculturenb-to-artsdata.yml | 06:15 daily |
| 7 | export-indigenous-performances-calendar-to-artsdata.yml | 06:30 daily |
